### PR TITLE
Adding support for more than 10 slides when using the --imageexport option

### DIFF
--- a/inkscapeslide/__init__.py
+++ b/inkscapeslide/__init__.py
@@ -148,7 +148,7 @@ def main():
         # Use the correct extension if using images
         if options.imageexport:
             pdfslide = os.path.abspath(os.path.join(os.curdir,
-                                                ".inkscapeslide_%s.p%d.png" % (FILENAME, i)))
+                                                ".inkscapeslide_%s.p%05d.png" % (FILENAME, i)))
 
         # Write the XML to file, "wireframes.p1.svg"
         f = open(svgslide, 'w')


### PR DESCRIPTION
Adding support for more than 10 slides when using the --imageexport option

```
* Using a hex string now instead of a decimal for the exported png image name,
  which ensures the joining of the images is done in the right order.  If you use
  a decimal to name the png files, the order will be 0,10,11,12,1,2,3..  Using hex
  eliminates this problem.
```
