### PR TITLE
Changed the PNG file naming when using -imageexport to support many layers.

### DIFF
--- a/inkscapeslide/__init__.py
+++ b/inkscapeslide/__init__.py
@@ -148,7 +148,7 @@ def main():
         # Use the correct extension if using images
         if options.imageexport:
             pdfslide = os.path.abspath(os.path.join(os.curdir,
-                                                ".inkscapeslide_%s.p%d.png" % (FILENAME, i)))
+                                                ".inkscapeslide_%s.p%05d.png" % (FILENAME, i)))
 
         # Write the XML to file, "wireframes.p1.svg"
         f = open(svgslide, 'w')


### PR DESCRIPTION
- When combinging the PNG files into a pdf, we are relying on the file names
  for ordering of the slides.  Since there were no leading zeros, we would run
  into an issue with slides joining out of order.
